### PR TITLE
Fixed updatename endpoint

### DIFF
--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -262,6 +262,13 @@ router.put("/update/email", (req, res) => {
 //update user name
 router.put("/update/name", (req, res) => {
     const user = Parse.User.current();
+
+    if(!user){
+      res.json({
+          result: "failure",
+          message: "No user logged in",
+      });
+    }
     
     user.set("name", req.body.name);
     


### PR DESCRIPTION
Endpoint now checks if user is logged in before allowing them to change their name